### PR TITLE
Remote command fix: left trim the "Reflector" argument.

### DIFF
--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -471,6 +471,8 @@ void CM17Gateway::run()
 				buffer[res] = '\0';
 				if (::memcmp(buffer + 0U, "Reflector", 9U) == 0) {
 					std::string reflector = std::string((char*)(buffer + 9U));
+					// left trim
+					reflector.erase(reflector.begin(), std::find_if(reflector.begin(), reflector.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
 					std::replace(reflector.begin(), reflector.end(), '_', ' ');
 					reflector.resize(M17_CALLSIGN_LENGTH, ' ');
 


### PR DESCRIPTION
  The argument is picked at buffer+9U, then forced fitted in CALLSIGN_LENGTH, hence reflector and module are invalid.
  e.g:
    - "RemoteCommand 6075 Reflector M17-M17_A" fails,
    - "RemoteCommand 6075 ReflectorM17-M17_A" works.