### PR TITLE
Handle signals like other Gateways.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ x64
 *.VC.db
 .vs
 M17Gateway
+GitVersion.h

--- a/M17Gateway.h
+++ b/M17Gateway.h
@@ -55,7 +55,7 @@ public:
 	CM17Gateway(const std::string& file);
 	~CM17Gateway();
 
-	void run();
+	int run();
 
 private:
 	CConf            m_conf;

--- a/M17Network.cpp
+++ b/M17Network.cpp
@@ -75,7 +75,7 @@ bool CM17Network::link(const std::string& name, const sockaddr_storage& addr, un
 	m_module  = module;
 
 	m_state = M17N_LINKING;
-
+	
 	sendConnect();
 
 	m_timer.start();
@@ -217,8 +217,9 @@ bool CM17Network::read(unsigned char* data)
 
 void CM17Network::close()
 {
-	if (m_state == M17N_LINKED) {
+	if ((m_state == M17N_LINKED) || (m_state == M17N_LINKING) || (m_state == M17N_FAILED)) {
 		m_socket.close();
+		m_state = M17N_NOTLINKED;
 		LogMessage("Closing M17 network connection");
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,22 @@ M17Gateway:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+M17Gateway.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
+clean:
+		$(RM) M17Gateway *.o *.d *.bak *~ GitVersion.h
+
 install:
 		install -m 755 M17Gateway /usr/local/bin/
 
-clean:
-		$(RM) M17Gateway *.o *.d *.bak *~
- 
+# Export the current git version if the index file exists, else 000...
+GitVersion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif


### PR DESCRIPTION
Handle connection failure/reconnection:
  - When restarting the software too quicly, the server returns a NACK, which was handled, but the reconnection wasn't, hence the link wasn't active anymore until to software was restarted.
  - Also, it was not possible to use RemoteCommand after that NACK on linking.
*NOTE*: there is still a problem with the Network ring buffer on some occasions (Overflow).