### PR TITLE
Add new remote command:

### DIFF
--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -556,6 +556,14 @@ int CM17Gateway::run()
 							hangTimer.stop();
 						}
 					}
+				} else if (::memcmp(buffer + 0U, "status", 6U) == 0) {
+					std::string state = std::string("m17:") + ((m_network == NULL) ? "n/a" : ((m_network->getStatus() == M17N_LINKED) ? "conn" : "disc"));
+					remoteSocket->write((unsigned char*)state.c_str(), (unsigned int)state.length(), addr, addrLen);
+				} else if (::memcmp(buffer + 0U, "host", 4U) == 0) {
+					std::string ref(m_reflector);
+					std::replace(ref.begin(), ref.end(), ' ', '_');
+					std::string host = std::string("m17:\"") + (((m_network == NULL) || (ref.length() == 0)) ? "NONE" : ref) + "\"";
+					remoteSocket->write((unsigned char*)host.c_str(), (unsigned int)host.length(), addr, addrLen);
 				} else {
 					CUtils::dump("Invalid remote command received", buffer, res);
 				}


### PR DESCRIPTION
 - status: displays network connection status (n/a, conn, disc), just like DMRGateway/MMDVMHost.
 - host: display connected host, or NONE if disconnected (surrounded with double quotes).

```
root@host:~ # RemoteCommand 6076 status
Command sent: "status" to port: 6076
m17:conn
```

```
root@host:~ # RemoteCommand 6076 host
Command sent: "host" to port: 6076
m17:"M17-FRA_D"
```