### PR TITLE
Relink on link loss.

### DIFF
--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -483,6 +483,19 @@ int CM17Gateway::run()
 				}
 			}
 		}
+		else {
+			if (m_status == M17S_LINKED) {
+				// If the link has failed, try and relink
+				M17NET_STATUS netStatus = m_network->getStatus();
+				if (netStatus == M17N_FAILED) {
+					LogMessage("Relinking to reflector %s", m_reflector.c_str());
+					m_status = M17S_LINKING;
+
+					if (voice != NULL)
+						voice->unlinked();
+				}
+			}
+		}
 
 		if (voice != NULL) {
 			if (triggerVoice) {
@@ -670,7 +683,7 @@ void CM17Gateway::linking()
 		return;
 
 	M17NET_STATUS status = m_network->getStatus();
-	if (status == M17N_NOTLINKED) {
+	if ((status == M17N_NOTLINKED) || (status == M17N_FAILED)) {
 		m_timer.start();
 		m_network->link(m_reflector, m_addr, m_addrLen, m_module);
 	} else if (status == M17N_LINKED) {

--- a/M17Network.cpp
+++ b/M17Network.cpp
@@ -137,7 +137,7 @@ void CM17Network::clock(unsigned int ms)
 		m_timeout.stop();
 	}
 
-	if (m_state == M17N_NOTLINKED)
+	if ((m_state == M17N_NOTLINKED) || (m_state == M17N_FAILED))
 		return;
 
 	unsigned char buffer[BUFFER_LENGTH];


### PR DESCRIPTION
Previously, once the link was lost, the Gateway was stuck in this state, making even harder to relink (had to unlink before relinking to the same reflector, using RemoteCommand).
