### PR TITLE
Fixes a bug where callsigns are truncated.

### DIFF
--- a/M17Defines.h
+++ b/M17Defines.h
@@ -19,7 +19,7 @@
 #if !defined(M17DEFINES_H)
 #define  M17DEFINES_H
 
-const unsigned int M17_CALLSIGN_LENGTH = 5U;
+const unsigned int M17_CALLSIGN_LENGTH = 9U;
 
 const unsigned int M17_NETWORK_FRAME_LENGTH = 54U;
 

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -273,7 +273,7 @@ int CM17Gateway::run()
 	if (!startupReflector.empty()) {
 		CM17Reflector* refl = reflectors.find(startupReflector);
 		if (refl != NULL) {
-			char module = startupReflector.at(M17_CALLSIGN_LENGTH - 1U);
+			char module = startupReflector.at(M17_CALLSIGN_LENGTH - 5U);
 			if (module >= 'A' && module <= 'Z') {
 				m_reflector = startupReflector;
 				m_addr      = refl->m_addr;
@@ -424,7 +424,7 @@ int CM17Gateway::run()
 				hangTimer.stop();
 			} else if (dst.size() == M17_CALLSIGN_LENGTH) {
 				std::string reflector = dst;
-				char module = reflector.at(M17_CALLSIGN_LENGTH - 1U);
+				char module = reflector.at(M17_CALLSIGN_LENGTH - 5U);
 
 				if (reflector != m_reflector && module >= 'A' && module <= 'Z') {
 					if (m_status == M17S_LINKED || m_status == M17S_LINKING) {
@@ -522,7 +522,7 @@ int CM17Gateway::run()
 
 						CM17Reflector* refl = reflectors.find(reflector);
 						if (refl != NULL) {
-							char module = reflector.at(M17_CALLSIGN_LENGTH - 1U);
+							char module = reflector.at(M17_CALLSIGN_LENGTH - 5U);
 							if (module >= 'A' && module <= 'Z') {
 								m_reflector = reflector;
 								m_addr      = refl->m_addr;
@@ -605,7 +605,7 @@ int CM17Gateway::run()
 				m_reflector = startupReflector;
 				m_addr      = refl->m_addr;
 				m_addrLen   = refl->m_addrLen;
-				m_module    = startupReflector.at(M17_CALLSIGN_LENGTH - 1U);
+				m_module    = startupReflector.at(M17_CALLSIGN_LENGTH - 5U);
 
 				m_status = m_oldStatus = M17S_LINKING;
 

--- a/Reflectors.cpp
+++ b/Reflectors.cpp
@@ -66,7 +66,7 @@ bool CReflectors::load()
 
 			if (p1 != NULL && p2 != NULL && p3 != NULL) {
 				std::string name = std::string(p1);
-				name.resize(M17_CALLSIGN_LENGTH - 2U, ' ');
+				name.resize(M17_CALLSIGN_LENGTH - 6U, ' ');
 
 				std::string host = std::string(p2);
 
@@ -103,7 +103,7 @@ bool CReflectors::load()
 			if (p1 != NULL && p2 != NULL && p3 != NULL) {
 				// Don't allow duplicate reflector ids from the secondary hosts file.
 				std::string name = std::string(p1);
-				name.resize(M17_CALLSIGN_LENGTH - 2U, ' ');
+				name.resize(M17_CALLSIGN_LENGTH - 6U, ' ');
 
 				if (find(name) == NULL) {
 					std::string host  = std::string(p2);

--- a/Version.h
+++ b/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20230104";
+const char* VERSION = "20230105";
 
 #endif


### PR DESCRIPTION
After merging PR #22  (dropping "M17-" prefix from hosts/reflectors), a bug was introduced that truncated callsigns. This PR addresses that bug, while keeping with the 3 char. host/reflector name.