### PR TITLE
Fixes an issue, where if a callsign contains an M17 Station ID (`-N`), and Secondary Operating Suffix (`/[A-Z]`), APRS-IS login fails.

### DIFF
--- a/APRSWriter.cpp
+++ b/APRSWriter.cpp
@@ -50,6 +50,16 @@ m_gpsdData()
 	assert(port > 0U);
 
 	if (!suffix.empty()) {
+		// The M17 spec allows for callsigns with a "Station ID" ("-N"); e,g. "W0CHP-1",
+		// as well as an M17 "Secondary Operating Suffixes" in the callsign; e.g. "W0CHP/H".
+		// Ergo, we need to strip the Station ID from the call, otherwise it will attempt
+		// to login to APRS-IS as "W0CHP-1-H" which is invalid, and as a result, fail to
+		// login to APRS-IS servers. Below, we strip the Station ID,  but append the
+		// native M17 suffix and an APRS suffix.
+		// 
+		// Strip the 17 callsign Station ID if present...
+		m_callsign = m_callsign.substr(0, m_callsign.find("-", 0));
+		// Append the M17 Secondary Operating Suffix
 		m_callsign.append("-");
 		m_callsign.append(suffix.substr(0U, 1U));
 	}


### PR DESCRIPTION
Issue: The M17 spec. allows for two callsign "appendages" in its encoding[^1]:

1. Station ID, `-N`; e.g. `W0CHP-1`
2. Secondary Operating Suffix. `/[A-Z]`; e.g. `W0CHP/H`

...and those can be combined, which is a valid callsign per the M17 spec.; e.g. `W0CHP-1/H`.

When 1 & 2 are present, the APRS-IS login fails, because the call being passed to the APRS-IS server (via `APRSGateway`) is sent as `W0CHP-1-H`.

This patch strips the `-N`  M17 Station ID from the APRS callsign/login (if present), but still appends the M17 Secondary Operating Suffix as the APRS suffix.
Patch is also backward-compat if the callsign does *not* contain an M17 Station ID.

[^1]: https://spec.m17project.org/appendix/address-encoding