### PR TITLE
Supports udp random local port

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -71,6 +71,7 @@ m_voiceEnabled(true),
 m_voiceLanguage("en_GB"),
 m_voiceDirectory(),
 m_networkPort(0U),
+m_networkLocalPort(0U),
 m_networkHosts1(),
 m_networkHosts2(),
 m_networkReloadTime(0U),
@@ -220,6 +221,8 @@ bool CConf::read()
 		} else if (section == SECTION_NETWORK) {
 			if (::strcmp(key, "Port") == 0)
 				m_networkPort = (unsigned short)::atoi(value);
+			else if (::strcmp(key, "LocalPort") == 0)
+				m_networkLocalPort = (unsigned short)::atoi(value);
 			else if (::strcmp(key, "HostsFile1") == 0)
 				m_networkHosts1 = value;
 			else if (::strcmp(key, "HostsFile2") == 0)
@@ -397,6 +400,11 @@ std::string CConf::getVoiceDirectory() const
 unsigned short CConf::getNetworkPort() const
 {
 	return m_networkPort;
+}
+
+unsigned short CConf::getNetworkLocalPort() const
+{
+	return m_networkLocalPort;
 }
 
 std::string CConf::getNetworkHosts1() const

--- a/Conf.h
+++ b/Conf.h
@@ -71,6 +71,7 @@ public:
 
 	// The Network section
 	unsigned short getNetworkPort() const;
+	unsigned short getNetworkLocalPort() const;
 	std::string    getNetworkHosts1() const;
 	std::string    getNetworkHosts2() const;
 	unsigned int   getNetworkReloadTime() const;
@@ -120,6 +121,7 @@ private:
 	std::string  m_voiceDirectory;
 
 	unsigned short m_networkPort;
+	unsigned short m_networkLocalPort;
 	std::string    m_networkHosts1;
 	std::string    m_networkHosts2;
 	unsigned int   m_networkReloadTime;

--- a/M17Gateway.cpp
+++ b/M17Gateway.cpp
@@ -228,7 +228,7 @@ int CM17Gateway::run()
 	if (!ret)
 		return -1;
 
-	m_network = new CM17Network(m_conf.getCallsign(), m_conf.getSuffix(), m_conf.getNetworkPort(), m_conf.getNetworkDebug());
+	m_network = new CM17Network(m_conf.getCallsign(), m_conf.getSuffix(), m_conf.getNetworkLocalPort(), m_conf.getNetworkDebug());
 
 	CUDPSocket* remoteSocket = NULL;
 	if (m_conf.getRemoteCommandsEnabled()) {

--- a/M17Network.cpp
+++ b/M17Network.cpp
@@ -43,7 +43,7 @@ m_timeout(1000U, 30U)
 {
 	assert(!callsign.empty());
 	assert(!suffix.empty());
-	assert(port > 0U);
+	// assert(port > 0U);
 
 	m_encoded = new unsigned char[6U];
 
@@ -251,6 +251,8 @@ void CM17Network::sendConnect()
 	buffer[9U] = m_encoded[5U];
 
 	buffer[10U] = m_module;
+
+	LogDebug("Connecting module %c", m_module);
 
 	if (m_debug)
 		CUtils::dump(1U, "M17 data transmitted", buffer, 11U);


### PR DESCRIPTION
Add a config item "LocalPort" to the "Network" section and user could configure it. If local port is not set , the random port will be used to communicate with the reflector.