### PR TITLE
fix missing cstdint, fixing compilation errors

### DIFF
--- a/M17Utils.cpp
+++ b/M17Utils.cpp
@@ -20,6 +20,7 @@
 #include "M17Defines.h"
 
 #include <cassert>
+#include <cstdint>
 
 const std::string M17_CHARS = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
 

--- a/Voice.h
+++ b/Voice.h
@@ -23,6 +23,7 @@
 #include "M17LSF.h"
 #include "Timer.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
While packaging M17Gateway for Alpine, I found that I needed a few headers for compilation to finish. These were sufficient.

Thanks for your work!